### PR TITLE
Update installOpenCV-3-raspberry-pi.sh

### DIFF
--- a/InstallScripts/installOpenCV-3-raspberry-pi.sh
+++ b/InstallScripts/installOpenCV-3-raspberry-pi.sh
@@ -111,13 +111,13 @@ echo "Complete"
 echo "Downloading opencv and opencv_contrib"
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 echo "================================"


### PR DESCRIPTION
Updated checkout argument for git (from 3.4 to "$cvVersion").
Current version (2019-02-20) checks out 3.4.5-dev instead of the expected 3.4.4 branch/release